### PR TITLE
Add sample interactive CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# Interactive CLI
+
+This project demonstrates a simple interactive command line interface built with [prompt_toolkit](https://github.com/prompt-toolkit/python-prompt-toolkit).
+
+## Setup
+
+Install the dependencies from `requirements.txt`:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+
+Run the CLI with Python:
+
+```bash
+python cli.py
+```
+
+You will be greeted with an interactive prompt. Type `help` to see available commands and `exit` to quit.

--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,30 @@
+from prompt_toolkit import PromptSession
+from prompt_toolkit.completion import WordCompleter
+
+
+def main():
+    session = PromptSession()
+    commands = ['help', 'exit', 'greet']
+    completer = WordCompleter(commands, ignore_case=True)
+    print('Interactive CLI. Type "help" for commands.')
+    while True:
+        try:
+            text = session.prompt('> ', completer=completer)
+        except KeyboardInterrupt:
+            continue
+        except EOFError:
+            break
+        cmd = text.strip().lower()
+        if cmd == 'exit':
+            break
+        elif cmd == 'help':
+            print('Available commands: ' + ', '.join(commands))
+        elif cmd == 'greet':
+            print('Hello!')
+        elif cmd:
+            print(f'Unknown command: {cmd}')
+    print('Goodbye!')
+
+
+if __name__ == '__main__':
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+prompt_toolkit>=3.0


### PR DESCRIPTION
## Summary
- add a simple interactive CLI using prompt_toolkit
- document setup and usage in README
- declare the dependency in requirements.txt

## Testing
- `python cli.py <<'EOF'
help
exit
EOF` *(fails: ModuleNotFoundError: No module named 'prompt_toolkit')*

------
https://chatgpt.com/codex/tasks/task_e_683ff00d1c208322ae005047fc7149b8