### PR TITLE
Add category and content CLI CRUD

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,21 @@ python cli.py
 ```
 
 You will be greeted with an interactive prompt. Type `help` to see available commands and `exit` to quit.
+
+The CLI now supports simple management of **categories** and **content** items. Each category may have a `parent` category. Content has `content_type`, `category` and `action` fields. Use the following commands to manage them:
+
+```
+add_category <name> [parent]
+list_categories
+get_category <name>
+update_category <name> <parent>
+delete_category <name>
+
+add_content <name> <content_type> <category> <action>
+list_contents
+get_content <name>
+update_content <name> <field> <value>
+delete_content <name>
+```
+
+These commands operate on in-memory data only and are intended for experimentation.

--- a/cli.py
+++ b/cli.py
@@ -1,11 +1,36 @@
+from dataclasses import dataclass, field
+from typing import Dict, Optional
+
 from prompt_toolkit import PromptSession
 from prompt_toolkit.completion import WordCompleter
 
 
+@dataclass
+class Category:
+    name: str
+    parent: Optional[str] = None
+
+
+@dataclass
+class Content:
+    name: str
+    content_type: str
+    category: str
+    action: str
+
+
 def main():
     session = PromptSession()
-    commands = ['help', 'exit', 'greet']
+    commands = [
+        'help', 'exit', 'greet',
+        'add_category', 'list_categories', 'get_category',
+        'update_category', 'delete_category',
+        'add_content', 'list_contents', 'get_content',
+        'update_content', 'delete_content',
+    ]
     completer = WordCompleter(commands, ignore_case=True)
+    categories: Dict[str, Category] = {}
+    contents: Dict[str, Content] = {}
     print('Interactive CLI. Type "help" for commands.')
     while True:
         try:
@@ -14,14 +39,126 @@ def main():
             continue
         except EOFError:
             break
-        cmd = text.strip().lower()
+        tokens = text.strip().split()
+        if not tokens:
+            continue
+        cmd = tokens[0].lower()
+
         if cmd == 'exit':
             break
         elif cmd == 'help':
             print('Available commands: ' + ', '.join(commands))
         elif cmd == 'greet':
             print('Hello!')
-        elif cmd:
+
+        elif cmd == 'add_category':
+            if len(tokens) < 2:
+                print('Usage: add_category <name> [parent]')
+                continue
+            name = tokens[1]
+            parent = tokens[2] if len(tokens) > 2 else None
+            categories[name] = Category(name=name, parent=parent)
+            print(f'Category "{name}" added.')
+
+        elif cmd == 'list_categories':
+            if categories:
+                for cat in categories.values():
+                    print(f'{cat.name} (parent: {cat.parent})')
+            else:
+                print('No categories.')
+
+        elif cmd == 'get_category':
+            if len(tokens) != 2:
+                print('Usage: get_category <name>')
+                continue
+            cat = categories.get(tokens[1])
+            if cat:
+                print(f'{cat.name} (parent: {cat.parent})')
+            else:
+                print('Category not found.')
+
+        elif cmd == 'update_category':
+            if len(tokens) != 3:
+                print('Usage: update_category <name> <parent>')
+                continue
+            name, parent = tokens[1], tokens[2]
+            cat = categories.get(name)
+            if cat:
+                cat.parent = parent
+                print('Category updated.')
+            else:
+                print('Category not found.')
+
+        elif cmd == 'delete_category':
+            if len(tokens) != 2:
+                print('Usage: delete_category <name>')
+                continue
+            if categories.pop(tokens[1], None):
+                print('Category deleted.')
+            else:
+                print('Category not found.')
+
+        elif cmd == 'add_content':
+            if len(tokens) != 5:
+                print('Usage: add_content <name> <content_type> <category> <action>')
+                continue
+            name, ctype, cat, action = tokens[1:5]
+            if cat not in categories:
+                print('Category does not exist.')
+                continue
+            contents[name] = Content(name=name, content_type=ctype, category=cat, action=action)
+            print(f'Content "{name}" added.')
+
+        elif cmd == 'list_contents':
+            if contents:
+                for c in contents.values():
+                    print(f'{c.name}: type={c.content_type} category={c.category} action={c.action}')
+            else:
+                print('No contents.')
+
+        elif cmd == 'get_content':
+            if len(tokens) != 2:
+                print('Usage: get_content <name>')
+                continue
+            c = contents.get(tokens[1])
+            if c:
+                print(f'{c.name}: type={c.content_type} category={c.category} action={c.action}')
+            else:
+                print('Content not found.')
+
+        elif cmd == 'update_content':
+            if len(tokens) != 4:
+                print('Usage: update_content <name> <field> <value>')
+                continue
+            name, field_name, value = tokens[1:4]
+            c = contents.get(name)
+            if not c:
+                print('Content not found.')
+                continue
+            if field_name == 'content_type':
+                c.content_type = value
+            elif field_name == 'category':
+                if value not in categories:
+                    print('Category does not exist.')
+                    continue
+                c.category = value
+            elif field_name == 'action':
+                c.action = value
+            else:
+                print('Unknown field.')
+                continue
+            print('Content updated.')
+
+        elif cmd == 'delete_content':
+            if len(tokens) != 2:
+                print('Usage: delete_content <name>')
+                continue
+            if contents.pop(tokens[1], None):
+                print('Content deleted.')
+            else:
+                print('Content not found.')
+
+        else:
             print(f'Unknown command: {cmd}')
     print('Goodbye!')
 


### PR DESCRIPTION
## Summary
- add Category and Content dataclasses
- extend CLI with CRUD commands for categories and content
- document new commands in README

## Testing
- `python -m py_compile cli.py`


------
https://chatgpt.com/codex/tasks/task_e_683ff4e1b1908322a4a1a3ab55106568