### PR TITLE
Add seed data and tab completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ list_contents
 get_content <name>
 update_content <name> <field> <value>
 delete_content <name>
+seed_data
 ```
 
 These commands operate on in-memory data only and are intended for experimentation.
+The `seed_data` command populates sample categories and contents representing a
+Catholic church homepage. Tab completion is available for commands and relevant
+arguments such as category names, content names, types and actions.


### PR DESCRIPTION
## Summary
- seed categories and content with a Catholic church example
- add `seed_data` command
- provide context aware tab completion for commands and arguments
- update documentation with new command and completion support

## Testing
- `python -m py_compile cli.py`
- `python cli.py <<'EOF'
help
exit
EOF` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_683ffc44c2b48322884122dd9a9e4c41