### PR TITLE
Implement tree view and editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,15 @@ get_content <name>
 update_content <name> <field> <value>
 delete_content <name>
 seed_data
+clear_all
+tree_view
+tree_edit <name> <parent>
 ```
 
 These commands operate on in-memory data only and are intended for experimentation.
-The `seed_data` command populates sample categories and contents representing a
-Catholic church homepage. Tab completion is available for commands and relevant
-arguments such as category names, content names, types and actions.
+On startup the CLI is pre-populated with sample categories and contents. The
+`seed_data` command can be used to reload this data at any time. `clear_all`
+removes all categories and contents. `tree_view` prints the categories in a
+hierarchical tree and `tree_edit` changes the parent of a category. Tab
+completion is available for commands and relevant arguments such as category
+names, content names, types and actions.


### PR DESCRIPTION
## Summary
- seed CMS data at startup
- add tree printing helper
- support `clear_all`, `tree_view` and `tree_edit` commands
- document the new commands

## Testing
- `python -m py_compile cli.py`
- `python cli.py -h` *(fails: ModuleNotFoundError: No module named 'prompt_toolkit')*

------
https://chatgpt.com/codex/tasks/task_e_683ffe91117c832290364e08056cc3a7