### PR TITLE
Add mouse-friendly tree_edit dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,15 @@ delete_content <name>
 seed_data
 clear_all
 tree_view
-tree_edit <name> <parent>
+tree_edit <name> [parent]
 ```
 
 These commands operate on in-memory data only and are intended for experimentation.
 On startup the CLI is pre-populated with sample categories and contents. The
 `seed_data` command can be used to reload this data at any time. `clear_all`
 removes all categories and contents. `tree_view` prints the categories in a
-hierarchical tree and `tree_edit` changes the parent of a category. Tab
-completion is available for commands and relevant arguments such as category
+hierarchical tree and `tree_edit` lets you change the parent of a category.
+When invoked without a parent argument, a mouse-friendly list of categories
+is displayed. Tab completion is available for commands and relevant arguments
+such as category
 names, content names, types and actions.


### PR DESCRIPTION
## Summary
- add a radiolist dialog with mouse support for `tree_edit`
- document the new optional parent argument usage

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68400421450083229432b642f20d1cce