### PR TITLE
Improve tree_edit usability

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ delete_content <name>
 seed_data
 clear_all
 tree_view
-tree_edit <name> [parent]
+tree_edit [name] [parent]
 ```
 
 These commands operate on in-memory data only and are intended for experimentation.
@@ -45,7 +45,8 @@ On startup the CLI is pre-populated with sample categories and contents. The
 `seed_data` command can be used to reload this data at any time. `clear_all`
 removes all categories and contents. `tree_view` prints the categories in a
 hierarchical tree and `tree_edit` lets you change the parent of a category.
-When invoked without a parent argument, a mouse-friendly list of categories
-is displayed. Tab completion is available for commands and relevant arguments
-such as category
+When run with no arguments, it opens a mouse-friendly chooser for the
+category and then the parent. If a name is provided but no parent, only the
+parent selection dialog is shown. Tab completion is available for commands
+and relevant arguments such as category
 names, content names, types and actions.

--- a/cms/cli.py
+++ b/cms/cli.py
@@ -155,14 +155,32 @@ def run_cli() -> None:
             else:
                 print('No categories.')
         elif cmd == 'tree_edit':
-            if len(tokens) not in {2, 3}:
-                print('Usage: tree_edit <name> [parent]')
+            if len(tokens) not in {1, 2, 3}:
+                print('Usage: tree_edit [name] [parent]')
                 continue
-            name = tokens[1]
+
+            if len(tokens) == 1:
+                if not categories:
+                    print('No categories.')
+                    continue
+                result = radiolist_dialog(
+                    title='Edit Category',
+                    text='Select category to edit:',
+                    values=[(n, n) for n in sorted(categories.keys())],
+                    mouse_support=True,
+                ).run()
+                if result is None:
+                    print('Edit cancelled.')
+                    continue
+                name = result
+            else:
+                name = tokens[1]
+
             cat = categories.get(name)
             if not cat:
                 print('Category not found.')
                 continue
+
             if len(tokens) == 3:
                 parent = tokens[2]
             else:
@@ -179,6 +197,7 @@ def run_cli() -> None:
                     print('Edit cancelled.')
                     continue
                 parent = result
+
             cat.parent = None if parent.lower() == 'none' else parent
             print('Category updated.')
         elif cmd == 'seed_data':


### PR DESCRIPTION
## Summary
- allow running `tree_edit` with no arguments
- document new workflow for selecting category and parent interactively

## Testing
- `python -m py_compile cli.py cms/*.py`

------
https://chatgpt.com/codex/tasks/task_e_684006a345b4832297c40d00559d1ba5