### PR TITLE
Improve tree_edit command

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ removes all categories and contents. `tree_view` prints the categories in a
 hierarchical tree and `tree_edit` lets you change the parent of a category.
 When run with no arguments, it opens a mouse-friendly chooser for the
 category and then the parent. If a name is provided but no parent, only the
-parent selection dialog is shown. Tab completion is available for commands
-and relevant arguments such as category
-names, content names, types and actions.
+parent selection dialog is shown. The command validates that the selected
+parent exists and is not the category itself. Tab completion is available
+for commands and relevant arguments such as category names, content names,
+types and actions.


### PR DESCRIPTION
## Summary
- refactor `tree_edit` command into helper function `handle_tree_edit`
- validate parent category and prevent self-parenting
- allow interactive selection helpers `_choose_category` and `_choose_parent`
- document new behaviour in README

## Testing
- `python -m py_compile cli.py cms/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68400778a4588322bdf6ae6131e5bbf5