### PR TITLE
Add interactive tree UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ seed_data
 clear_all
 tree_view
 tree_edit [name] [parent]
+tree_ui
 ```
 
 These commands operate on in-memory data only and are intended for experimentation.
@@ -45,6 +46,8 @@ On startup the CLI is pre-populated with sample categories and contents. The
 `seed_data` command can be used to reload this data at any time. `clear_all`
 removes all categories and contents. `tree_view` prints the categories in a
 hierarchical tree and `tree_edit` lets you change the parent of a category.
+The `tree_ui` command opens a full-screen tree browser that allows renaming and
+re-parenting categories using the keyboard or mouse.
 When run with no arguments, it opens a mouse-friendly chooser for the
 category and then the parent. If a name is provided but no parent, only the
 parent selection dialog is shown. The command validates that the selected

--- a/cms/cli.py
+++ b/cms/cli.py
@@ -16,7 +16,7 @@ COMMANDS = [
     'update_category', 'delete_category',
     'add_content', 'list_contents', 'get_content',
     'update_content', 'delete_content',
-    'seed_data', 'clear_all', 'tree_view', 'tree_edit'
+    'seed_data', 'clear_all', 'tree_view', 'tree_edit', 'tree_ui'
 ]
 
 
@@ -222,6 +222,12 @@ def run_cli() -> None:
                 print('No categories.')
         elif cmd == 'tree_edit':
             handle_tree_edit(tokens, categories)
+        elif cmd == 'tree_ui':
+            if categories:
+                from .tree_ui import TreeEditor
+                TreeEditor(categories).run()
+            else:
+                print('No categories.')
         elif cmd == 'seed_data':
             seed_data(categories, contents)
             print('Sample data loaded.')

--- a/cms/tree_ui.py
+++ b/cms/tree_ui.py
@@ -1,0 +1,225 @@
+"""Interactive tree viewer and editor for categories."""
+
+from __future__ import annotations
+
+from typing import Dict, List, Optional, Tuple
+
+from prompt_toolkit.application import Application
+from prompt_toolkit.key_binding import KeyBindings
+from prompt_toolkit.layout import HSplit, Layout, Window
+from prompt_toolkit.layout.controls import FormattedTextControl
+from prompt_toolkit.shortcuts import input_dialog, radiolist_dialog
+from prompt_toolkit.mouse_events import MouseEventType
+from prompt_toolkit.styles import Style
+
+from .models import Category
+
+
+class TreeNode:
+    """Node used by :class:`TreeEditor`."""
+
+    def __init__(self, name: str, category: Optional[Category] = None):
+        self.name = name
+        self.category = category
+        self.children: List["TreeNode"] = []
+        self.expanded = False
+
+    def toggle(self) -> None:
+        if self.children:
+            self.expanded = not self.expanded
+
+
+class TreeEditor:
+    """Full screen tree browser with rename and move commands."""
+
+    def __init__(self, categories: Dict[str, Category]):
+        self.categories = categories
+        self.selected_index = 0
+        self.root = self._build_tree()
+        self._lines: List[Tuple[TreeNode, str]] = []
+        self.bindings = self._create_bindings()
+        self.style = Style.from_dict({
+            "line": "bg:#444444",
+            "status": "bg:#222222 #aaaaaa",
+        })
+        self.app = self._create_app()
+
+    # ------------------------------------------------------------------ utils
+    def _build_tree(self) -> TreeNode:
+        nodes = {name: TreeNode(name, c) for name, c in self.categories.items()}
+        root = TreeNode("ROOT")
+        for name, cat in self.categories.items():
+            node = nodes[name]
+            if cat.parent and cat.parent in nodes:
+                nodes[cat.parent].children.append(node)
+            else:
+                root.children.append(node)
+        root.expanded = True
+        return root
+
+    def _visible_lines(self, node: TreeNode, prefix: str = "") -> List[Tuple[TreeNode, str]]:
+        lines: List[Tuple[TreeNode, str]] = []
+        icon = "   "
+        if node.children:
+            icon = "[-]" if node.expanded else "[+]"
+        lines.append((node, f"{prefix}{icon} {node.name}"))
+        if node.expanded:
+            for child in node.children:
+                lines.extend(self._visible_lines(child, prefix + "    "))
+        return lines
+
+    def _collect_descendants(self, node: TreeNode) -> List[str]:
+        names = []
+        for child in node.children:
+            names.append(child.name)
+            names.extend(self._collect_descendants(child))
+        return names
+
+    # -------------------------------------------------------------- operations
+    def _rename_node(self) -> None:
+        node, _ = self._lines[self.selected_index]
+        new_name = input_dialog(
+            title="Rename Category",
+            text=f"Enter new name for '{node.name}':",
+            default=node.name,
+        ).run()
+        if new_name and new_name != node.name:
+            old_name = node.name
+            cat = self.categories.pop(old_name)
+            cat.name = new_name
+            self.categories[new_name] = cat
+            for c in self.categories.values():
+                if c.parent == old_name:
+                    c.parent = new_name
+            self.root = self._build_tree()
+            self._reset_selection(new_name)
+            self.app.invalidate()
+
+    def _change_parent(self) -> None:
+        node, _ = self._lines[self.selected_index]
+        exclude = set(self._collect_descendants(node)) | {node.name}
+        options = [('none', 'None')] + [
+            (name, name) for name in sorted(self.categories.keys()) if name not in exclude
+        ]
+        result = radiolist_dialog(
+            title="Change Parent",
+            text=f"Select new parent for '{node.name}':",
+            values=options,
+        ).run()
+        if result is None:
+            return
+        new_parent = None if result == 'none' else result
+        self.categories[node.name].parent = new_parent
+        self.root = self._build_tree()
+        self._reset_selection(node.name)
+        self.app.invalidate()
+
+    def _reset_selection(self, name: str) -> None:
+        self.selected_index = 0
+        for i, (n, _) in enumerate(self._visible_lines(self.root)):
+            if n.name == name:
+                self.selected_index = i
+                break
+
+    # ---------------------------------------------------------------- bindings
+    def _create_bindings(self) -> KeyBindings:
+        kb = KeyBindings()
+
+        @kb.add("up")
+        def _up(event) -> None:
+            if self.selected_index > 0:
+                self.selected_index -= 1
+                event.app.invalidate()
+
+        @kb.add("down")
+        def _down(event) -> None:
+            if self.selected_index < len(self._lines) - 1:
+                self.selected_index += 1
+                event.app.invalidate()
+
+        @kb.add("right")
+        def _expand(event) -> None:
+            node, _ = self._lines[self.selected_index]
+            if node.children and not node.expanded:
+                node.expanded = True
+                event.app.invalidate()
+
+        @kb.add("left")
+        def _collapse(event) -> None:
+            node, _ = self._lines[self.selected_index]
+            if node.children and node.expanded:
+                node.expanded = False
+                event.app.invalidate()
+            else:
+                current_text = self._lines[self.selected_index][1]
+                current_indent = len(current_text) - len(current_text.lstrip())
+                for i in range(self.selected_index - 1, -1, -1):
+                    text_i = self._lines[i][1]
+                    indent_i = len(text_i) - len(text_i.lstrip())
+                    if indent_i < current_indent:
+                        self.selected_index = i
+                        event.app.invalidate()
+                        return
+
+        @kb.add("r")
+        def _rename(event) -> None:
+            self._rename_node()
+
+        @kb.add("p")
+        def _parent(event) -> None:
+            self._change_parent()
+
+        @kb.add("q")
+        def _quit(event) -> None:
+            event.app.exit()
+
+        return kb
+
+    # ------------------------------------------------------------------ layout
+    def _render(self):
+        fragments = []
+        self._lines = self._visible_lines(self.root)
+        if not self._lines:
+            return fragments
+        if self.selected_index < 0:
+            self.selected_index = 0
+        if self.selected_index >= len(self._lines):
+            self.selected_index = len(self._lines) - 1
+        for idx, (node, text) in enumerate(self._lines):
+            style = "reverse" if idx == self.selected_index else ""
+            fragments.append((style, text + "\n", self._mouse_handler(node, idx)))
+        return fragments
+
+    def _mouse_handler(self, node: TreeNode, idx: int):
+        def handler(mouse_event):
+            if mouse_event.event_type == MouseEventType.MOUSE_UP:
+                self.selected_index = idx
+                if node.children:
+                    node.toggle()
+                self.app.invalidate()
+        return handler
+
+    def _create_app(self) -> Application:
+        tree_control = FormattedTextControl(self._render, focusable=True, show_cursor=False)
+        tree_window = Window(content=tree_control, wrap_lines=False)
+        body = HSplit([
+            tree_window,
+            Window(height=1, char="─", style="class:line"),
+            Window(content=FormattedTextControl(lambda: [
+                ("class:status", " ↑/↓ move, ←/→ collapse/expand, R rename, P change parent, Q quit ")
+            ]), height=1),
+        ])
+        app = Application(
+            layout=Layout(body, focused_element=tree_window),
+            key_bindings=self.bindings,
+            mouse_support=True,
+            full_screen=True,
+            style=self.style,
+        )
+        return app
+
+    # ---------------------------------------------------------------------- API
+    def run(self) -> None:
+        """Run the interactive editor."""
+        self.app.run()
+


### PR DESCRIPTION
## Summary
- add a prompt_toolkit-based tree browser with rename and re-parent commands
- expose the browser through a new `tree_ui` CLI command
- document `tree_ui` usage

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68400cc171d48322b97debd6ae598df6