### PR TITLE
Implement interactive tree_edit

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,14 @@ delete_content <name>
 seed_data
 clear_all
 tree_view
-tree_edit <name> <parent>
+tree_edit [name] [parent]
 ```
 
 These commands operate on in-memory data only and are intended for experimentation.
 On startup the CLI is pre-populated with sample categories and contents. The
 `seed_data` command can be used to reload this data at any time. `clear_all`
 removes all categories and contents. `tree_view` prints the categories in a
-hierarchical tree and `tree_edit` changes the parent of a category. Tab
-completion is available for commands and relevant arguments such as category
-names, content names, types and actions.
+hierarchical tree and `tree_edit` without arguments opens an interactive mode
+for renaming, moving or deleting categories. Tab completion is available for
+commands and relevant arguments such as category names, content names, types and
+actions.

--- a/cms/cli.py
+++ b/cms/cli.py
@@ -5,7 +5,7 @@ from typing import Dict
 from prompt_toolkit import PromptSession
 
 from .completer import CmsCompleter
-from .data import print_category_tree, seed_data
+from .data import print_category_tree, seed_data, interactive_tree_edit
 from .models import Category, Content
 
 
@@ -154,16 +154,20 @@ def run_cli() -> None:
             else:
                 print('No categories.')
         elif cmd == 'tree_edit':
-            if len(tokens) != 3:
-                print('Usage: tree_edit <name> <parent>')
+            if len(tokens) > 3:
+                print('Usage: tree_edit [name] [parent]')
                 continue
-            name, parent = tokens[1], tokens[2]
-            cat = categories.get(name)
-            if cat:
-                cat.parent = None if parent.lower() == 'none' else parent
-                print('Category updated.')
+            name = tokens[1] if len(tokens) >= 2 else None
+            parent = tokens[2] if len(tokens) == 3 else None
+            if name is not None and parent is not None:
+                cat = categories.get(name)
+                if cat:
+                    cat.parent = None if parent.lower() == 'none' else parent
+                    print('Category updated.')
+                else:
+                    print('Category not found.')
             else:
-                print('Category not found.')
+                interactive_tree_edit(categories)
         elif cmd == 'seed_data':
             seed_data(categories, contents)
             print('Sample data loaded.')

--- a/cms/data.py
+++ b/cms/data.py
@@ -51,3 +51,58 @@ def print_category_tree(categories: Dict[str, Category]) -> None:
             _print(child, indent + 1)
 
     _print(None)
+
+
+def interactive_tree_edit(categories: Dict[str, Category]) -> None:
+    """Interactively modify categories using simple key shortcuts."""
+
+    def rename_category() -> None:
+        name = input('Category to rename: ').strip()
+        if name not in categories:
+            print('Category not found.')
+            return
+        new_name = input('New name: ').strip()
+        if not new_name:
+            print('Name cannot be empty.')
+            return
+        cat = categories.pop(name)
+        cat.name = new_name
+        categories[new_name] = cat
+        for c in categories.values():
+            if c.parent == name:
+                c.parent = new_name
+
+    def change_parent() -> None:
+        name = input('Category to move: ').strip()
+        if name not in categories:
+            print('Category not found.')
+            return
+        parent = input('New parent (blank for none): ').strip() or None
+        categories[name].parent = parent
+
+    def delete_category() -> None:
+        name = input('Category to delete: ').strip()
+        if name not in categories:
+            print('Category not found.')
+            return
+        categories.pop(name)
+        for c in categories.values():
+            if c.parent == name:
+                c.parent = None
+
+    actions = {
+        'r': rename_category,
+        'e': change_parent,
+        'd': delete_category,
+    }
+
+    while True:
+        print_category_tree(categories)
+        choice = input('[r]ename, [e]dit parent, [d]elete, [q]uit: ').strip().lower()
+        if choice == 'q':
+            break
+        action = actions.get(choice)
+        if action:
+            action()
+        else:
+            print('Unknown choice.')


### PR DESCRIPTION
## Summary
- allow optional args for `tree_edit` and add interactive editing
- expose `interactive_tree_edit` to CLI
- update documentation about tree_edit

## Testing
- `python -m py_compile cms/*.py cli.py`

------
https://chatgpt.com/codex/tasks/task_e_68402540b43483229aa501824243383f