### PR TITLE
Fix interactive tree edit initial display

### DIFF
--- a/cms/data.py
+++ b/cms/data.py
@@ -246,7 +246,5 @@ def interactive_tree_edit(categories: Dict[str, Category]) -> None:
     def _(event) -> None:
         event.app.exit()
 
-    refresh()
-
-    app = Application(layout=Layout(TextArea('')), key_bindings=kb, full_screen=True)
-    app.run()
+    app = Application(layout=Layout(TextArea("")), key_bindings=kb, full_screen=True)
+    app.run(pre_run=refresh)


### PR DESCRIPTION
## Summary
- ensure `tree_edit` shows the category tree immediately

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68402eb97a888322a637317ca0f9e78f