### PR TITLE
Add content panel to tree UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ removes all categories and contents. `tree_view` prints the categories in a
 hierarchical tree and `tree_edit` lets you change the parent of a category.
 The `tree_ui` command opens a full-screen tree browser. A right-click context
 menu allows inline renaming or deleting of categories. You can still rename or
-re-parent using the keyboard shortcuts as well.
+re-parent using the keyboard shortcuts as well. The tree now displays a content
+panel on the right showing items for the selected category.
 When run with no arguments, it opens a mouse-friendly chooser for the
 category and then the parent. If a name is provided but no parent, only the
 parent selection dialog is shown. The command validates that the selected

--- a/cms/cli.py
+++ b/cms/cli.py
@@ -225,7 +225,7 @@ def run_cli() -> None:
         elif cmd == 'tree_ui':
             if categories:
                 from .tree_ui import TreeEditor
-                TreeEditor(categories).run()
+                TreeEditor(categories, contents).run()
             else:
                 print('No categories.')
         elif cmd == 'seed_data':


### PR DESCRIPTION
## Summary
- add a content side panel in tree_ui showing items for the selected category
- update CLI to pass content data to the UI
- document new tree_ui behaviour in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684034d2a8088322ac8985332d2fcb72