### PR TITLE
Add CMS root menu element

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ tree_ui
 
 These commands operate on in-memory data only and are intended for experimentation.
 On startup the CLI is pre-populated with sample categories and contents. The
-`seed_data` command can be used to reload this data at any time. `clear_all`
+menu is organized under a root category called `CMS`, with items like `Home` and
+`About` appearing as children. The `seed_data` command can be used to reload this data at any time. `clear_all`
 removes all categories and contents. `tree_view` prints the categories in a
 hierarchical tree and `tree_edit` lets you change the parent of a category.
 The `tree_ui` command opens a full-screen tree browser. A right-click context

--- a/cms/data.py
+++ b/cms/data.py
@@ -10,13 +10,15 @@ def seed_data(categories: Dict[str, Category], contents: Dict[str, Content]) -> 
     categories.clear()
     contents.clear()
 
+    # Create a root CMS node so that all menu items are grouped under it.
     seed_categories = {
-        'Home': Category('Home'),
-        'About': Category('About'),
-        'Mass Times': Category('Mass Times'),
-        'Sacraments': Category('Sacraments'),
-        'Ministries': Category('Ministries'),
-        'Downloads': Category('Downloads'),
+        "CMS": Category("CMS"),
+        'Home': Category('Home', parent='CMS'),
+        'About': Category('About', parent='CMS'),
+        'Mass Times': Category('Mass Times', parent='CMS'),
+        'Sacraments': Category('Sacraments', parent='CMS'),
+        'Ministries': Category('Ministries', parent='CMS'),
+        'Downloads': Category('Downloads', parent='CMS'),
         'Staff': Category('Staff', parent='About'),
         'History': Category('History', parent='About'),
         'Contact': Category('Contact', parent='About'),


### PR DESCRIPTION
## Summary
- seed the sample data with a `CMS` root category so all menu items are children of it
- document the new `CMS` root grouping in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684041f8d0e483228a1ae07637750b93