### PR TITLE
Remove CMS root category

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,9 @@ tree_ui
 ```
 
 These commands operate on in-memory data only and are intended for experimentation.
-On startup the CLI is pre-populated with sample categories and contents. The
-menu is organized under a root category called `CMS`, with items like `Home` and
-`About` appearing as children. The `seed_data` command can be used to reload this data at any time. `clear_all`
+On startup the CLI is pre-populated with sample categories and contents. Top
+level items such as `Home` and `About` appear directly in the menu. The
+`seed_data` command can be used to reload this data at any time. `clear_all`
 removes all categories and contents. `tree_view` prints the categories in a
 hierarchical tree and `tree_edit` lets you change the parent of a category.
 The `tree_ui` command opens the same PyQt window for editing categories and

--- a/data.py
+++ b/data.py
@@ -10,15 +10,14 @@ def seed_data(categories: Dict[str, Category], contents: Dict[str, Content]) -> 
     categories.clear()
     contents.clear()
 
-    # Create a root CMS node so that all menu items are grouped under it.
+    # Top level categories are created without a dedicated root node.
     seed_categories = {
-        "CMS": Category("CMS"),
-        'Home': Category('Home', parent='CMS'),
-        'About': Category('About', parent='CMS'),
-        'Mass Times': Category('Mass Times', parent='CMS'),
-        'Sacraments': Category('Sacraments', parent='CMS'),
-        'Ministries': Category('Ministries', parent='CMS'),
-        'Downloads': Category('Downloads', parent='CMS'),
+        'Home': Category('Home'),
+        'About': Category('About'),
+        'Mass Times': Category('Mass Times'),
+        'Sacraments': Category('Sacraments'),
+        'Ministries': Category('Ministries'),
+        'Downloads': Category('Downloads'),
         'Staff': Category('Staff', parent='About'),
         'History': Category('History', parent='About'),
         'Contact': Category('Contact', parent='About'),


### PR DESCRIPTION
## Summary
- remove the artificial `CMS` root from seeded data
- update README description of default categories

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_6841649bab4c8322a9d3e9726b447805