### PR TITLE
Refactor data model for articles

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ You can also launch the GUI directly without entering the CLI:
 python gui.py
 ```
 
-The CLI now supports simple management of **categories** and **content** items. Each category may have a `parent` category. Content has `content_type`, `category` and `action` fields. Use the following commands to manage them:
+The CLI now supports simple management of **categories** and **articles**. Each category has an optional `parent` and a `sort_order_index`. Articles store a list of categories and an `archived` flag. Use the following commands to manage them:
 
 ```
 add_category <name> [parent]
@@ -39,7 +39,7 @@ get_category <name>
 update_category <name> <parent>
 delete_category <name>
 
-add_content <name> <content_type> <category> <action>
+add_content <name> <categories> [archived]
 list_contents
 get_content <name>
 update_content <name> <field> <value>
@@ -52,17 +52,16 @@ tree_ui
 ```
 
 These commands operate on in-memory data only and are intended for experimentation.
-On startup the CLI is pre-populated with sample categories and contents. Top
+On startup the CLI is pre-populated with sample categories and articles. Top
 level items such as `Home` and `About` appear directly in the menu. The
 `seed_data` command can be used to reload this data at any time. `clear_all`
-removes all categories and contents. `tree_view` prints the categories in a
+removes all categories and articles. `tree_view` prints the categories in a
 hierarchical tree and `tree_edit` lets you change the parent of a category.
 The `tree_ui` command opens the same PyQt window for editing categories and
-contents. Right-click a category to rename or delete it and double click a
-content item to edit its fields.
+articles. Right-click a category to rename or delete it and double click an
+article item to edit its fields.
 When run with no arguments, it opens a mouse-friendly chooser for the
 category and then the parent. If a name is provided but no parent, only the
 parent selection dialog is shown. The command validates that the selected
 parent exists and is not the category itself. Tab completion is available
-for commands and relevant arguments such as category names, content names,
-types and actions.
+for commands and relevant arguments such as category names and article names.

--- a/completer.py
+++ b/completer.py
@@ -4,13 +4,13 @@ from typing import Dict, Iterable
 
 from prompt_toolkit.completion import Completer, Completion
 
-from models import Category, Content
+from models import Category, Article
 
 
 class CmsCompleter(Completer):
     """Context aware tab completion for the CLI."""
 
-    def __init__(self, commands: Iterable[str], categories: Dict[str, Category], contents: Dict[str, Content]):
+    def __init__(self, commands: Iterable[str], categories: Dict[str, Category], contents: Dict[str, Article]):
         self.commands = list(commands)
         self.categories = categories
         self.contents = contents
@@ -50,22 +50,18 @@ class CmsCompleter(Completer):
             if arg_index == 1:
                 yield from yield_words(self.contents.keys())
             elif arg_index == 2:
-                yield from yield_words(['content_type', 'category', 'action'])
+                yield from yield_words(['categories', 'archived'])
             elif arg_index == 3:
                 field = tokens[2]
-                if field == 'content_type':
-                    yield from yield_words(['office_info', 'tinymce', 'pdf', 'banner'])
-                elif field == 'category':
+                if field == 'categories':
                     yield from yield_words(self.categories.keys())
-                elif field == 'action':
-                    yield from yield_words(['delete', 'update', 'new'])
+                elif field == 'archived':
+                    yield from yield_words(['true', 'false'])
         elif cmd == 'add_content':
             if arg_index == 2:
-                yield from yield_words(['office_info', 'tinymce', 'pdf', 'banner'])
-            elif arg_index == 3:
                 yield from yield_words(self.categories.keys())
-            elif arg_index == 4:
-                yield from yield_words(['delete', 'update', 'new'])
+            elif arg_index == 3:
+                yield from yield_words(['true', 'false'])
         elif cmd == 'tree_edit':
             if arg_index == 1:
                 yield from yield_words(self.categories.keys())

--- a/data.py
+++ b/data.py
@@ -3,40 +3,40 @@
 from typing import Dict, List, Optional
 import json
 
-from models import Category, Content
+from models import Category, Article
 
 
-def seed_data(categories: Dict[str, Category], contents: Dict[str, Content]) -> None:
+def seed_data(categories: Dict[str, Category], contents: Dict[str, Article]) -> None:
     """Populate dictionaries with sample catholic church data."""
     categories.clear()
     contents.clear()
 
     # Top level categories are created without a dedicated root node.
     seed_categories = {
-        'Home': Category('Home'),
-        'About': Category('About'),
-        'Mass Times': Category('Mass Times'),
-        'Sacraments': Category('Sacraments'),
-        'Ministries': Category('Ministries'),
-        'Downloads': Category('Downloads'),
-        'Staff': Category('Staff', parent='About'),
-        'History': Category('History', parent='About'),
-        'Contact': Category('Contact', parent='About'),
-        'Baptism': Category('Baptism', parent='Sacraments'),
-        'Confirmation': Category('Confirmation', parent='Sacraments'),
-        'Marriage': Category('Marriage', parent='Sacraments'),
-        'Youth Ministry': Category('Youth Ministry', parent='Ministries'),
-        'Choir': Category('Choir', parent='Ministries'),
-        'High School': Category('High School', parent='Youth Ministry'),
+        'Home': Category('Home', sort_order_index=0),
+        'About': Category('About', sort_order_index=1),
+        'Mass Times': Category('Mass Times', sort_order_index=2),
+        'Sacraments': Category('Sacraments', sort_order_index=3),
+        'Ministries': Category('Ministries', sort_order_index=4),
+        'Downloads': Category('Downloads', sort_order_index=5),
+        'Staff': Category('Staff', parent='About', sort_order_index=0),
+        'History': Category('History', parent='About', sort_order_index=1),
+        'Contact': Category('Contact', parent='About', sort_order_index=2),
+        'Baptism': Category('Baptism', parent='Sacraments', sort_order_index=0),
+        'Confirmation': Category('Confirmation', parent='Sacraments', sort_order_index=1),
+        'Marriage': Category('Marriage', parent='Sacraments', sort_order_index=2),
+        'Youth Ministry': Category('Youth Ministry', parent='Ministries', sort_order_index=0),
+        'Choir': Category('Choir', parent='Ministries', sort_order_index=1),
+        'High School': Category('High School', parent='Youth Ministry', sort_order_index=0),
     }
     categories.update(seed_categories)
 
     seed_contents = {
-        'office_hours': Content('office_hours', 'office_info', 'Home', 'update'),
-        'welcome': Content('welcome', 'tinymce', 'Home', 'new'),
-        'bulletin': Content('bulletin', 'pdf', 'Downloads', 'update'),
-        'youth_banner': Content('youth_banner', 'banner', 'Youth Ministry', 'new'),
-        'old_news': Content('old_news', 'tinymce', 'Home', 'delete'),
+        'office_hours': Article('office_hours', ['Home'], False),
+        'welcome': Article('welcome', ['Home'], False),
+        'bulletin': Article('bulletin', ['Downloads'], False),
+        'youth_banner': Article('youth_banner', ['Youth Ministry'], False),
+        'old_news': Article('old_news', ['Home'], True),
     }
     contents.update(seed_contents)
 
@@ -55,18 +55,22 @@ def print_category_tree(categories: Dict[str, Category]) -> None:
     _print(None)
 
 
-def export_json(categories: Dict[str, Category], contents: Dict[str, Content]) -> str:
+def export_json(categories: Dict[str, Category], contents: Dict[str, Article]) -> str:
     """Return a JSON string representing the current tree data."""
     data = {
         "categories": [
-            {"name": c.name, "parent": c.parent} for c in categories.values()
+            {
+                "name": c.name,
+                "parent": c.parent,
+                "sort_order_index": c.sort_order_index,
+            }
+            for c in categories.values()
         ],
         "contents": [
             {
                 "name": c.name,
-                "content_type": c.content_type,
-                "category": c.category,
-                "action": c.action,
+                "categories": c.categories,
+                "archived": c.archived,
             }
             for c in contents.values()
         ],
@@ -75,18 +79,21 @@ def export_json(categories: Dict[str, Category], contents: Dict[str, Content]) -
 
 
 def load_json(
-    json_str: str, categories: Dict[str, Category], contents: Dict[str, Content]
+    json_str: str, categories: Dict[str, Category], contents: Dict[str, Article]
 ) -> None:
     """Populate ``categories`` and ``contents`` from a JSON string."""
     data = json.loads(json_str)
     categories.clear()
     contents.clear()
     for cat in data.get("categories", []):
-        categories[cat["name"]] = Category(cat["name"], cat.get("parent"))
+        categories[cat["name"]] = Category(
+            cat["name"],
+            cat.get("parent"),
+            cat.get("sort_order_index", 0),
+        )
     for cont in data.get("contents", []):
-        contents[cont["name"]] = Content(
+        contents[cont["name"]] = Article(
             cont["name"],
-            cont["content_type"],
-            cont["category"],
-            cont["action"],
+            list(cont.get("categories", [])),
+            cont.get("archived", False),
         )

--- a/gui.py
+++ b/gui.py
@@ -1,9 +1,9 @@
 from data import seed_data
-from models import Category, Content
+from models import Category, Article
 from tree_gui import TreeGui
 
 if __name__ == '__main__':
     categories: dict[str, Category] = {}
-    contents: dict[str, Content] = {}
+    contents: dict[str, Article] = {}
     seed_data(categories, contents)
     TreeGui(categories, contents).run()

--- a/models.py
+++ b/models.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Optional
+from typing import Optional, List
 
 
 @dataclass
@@ -8,13 +8,13 @@ class Category:
 
     name: str
     parent: Optional[str] = None
+    sort_order_index: int = 0
 
 
 @dataclass
-class Content:
-    """Represents a content item."""
+class Article:
+    """Represents an article item."""
 
     name: str
-    content_type: str
-    category: str
-    action: str
+    categories: List[str]
+    archived: bool = False


### PR DESCRIPTION
## Summary
- refactor Category and Content models
- update seed data, CLI, and completer for articles
- adjust PyQt UIs for new article fields and category ordering
- revise README to document updated commands

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6841fb98ac0c8322ad0becaad899eae0