### PR TITLE
Fix accidental reorder bug

### DIFF
--- a/tree_gui.py
+++ b/tree_gui.py
@@ -31,9 +31,9 @@ class DragTreeWidget(QTreeWidget):
     def __init__(self, on_drop, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._on_drop = on_drop
-        self.setDragEnabled(True)
-        self.setAcceptDrops(True)
-        self.setDragDropMode(QAbstractItemView.InternalMove)
+        self.setDragEnabled(False)
+        self.setAcceptDrops(False)
+        self.setDragDropMode(QAbstractItemView.NoDragDrop)
 
     def dropEvent(self, event):
         super().dropEvent(event)


### PR DESCRIPTION
## Summary
- disable drag and drop operations on the tree widget

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684204bd0a4c8322bc59f68af9d7cff1