### PR TITLE
Fix category sort UI

### DIFF
--- a/tree_gui.py
+++ b/tree_gui.py
@@ -31,9 +31,10 @@ class DragTreeWidget(QTreeWidget):
     def __init__(self, on_drop, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._on_drop = on_drop
-        self.setDragEnabled(False)
-        self.setAcceptDrops(False)
-        self.setDragDropMode(QAbstractItemView.NoDragDrop)
+        # Enable drag and drop so categories can be reordered
+        self.setDragEnabled(True)
+        self.setAcceptDrops(True)
+        self.setDragDropMode(QAbstractItemView.InternalMove)
 
     def dropEvent(self, event):
         super().dropEvent(event)


### PR DESCRIPTION
## Summary
- restore drag & drop support for reordering categories in the GUI

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_68423d8b8e648322b92c23ea84045fa9